### PR TITLE
Fix broken links with the corrected ones

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,4 +45,4 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org "Contributor Covenant homepage"), [version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html "Code of Conduct version 1.4").
 
-For answers to common questions about this code of conduct, see [the Contributor Covenant FAQ](https://www.contributor-covenant.org/faq)
+For answers to common questions about this code of conduct, see [the Contributor Covenant FAQ](https://github.com/OWASP/owasp-mastg/blob/master/.github/CODE_OF_CONDUCT.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Learn how you can contribute to the OWASP Mobile Application Security Project [here](https://mas.owasp.org/contributing/1_How_Can_You_Contribute/).
+Learn how you can contribute to the OWASP Mobile Application Security Project [here](https://mas.owasp.org/MASTG/0x02c-Acknowledgements/).

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ pitch: The OWASP Mobile Application Security (MAS) project consists of a series 
 [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship%20project-48A646.svg)](https://owasp.org/projects/#owasp-project-inventory-256)
 ![Github stars MASTG](https://img.shields.io/github/stars/OWASP/owasp-mastg?label=Stars%20MSTG&style=social)
 ![Github stars MASVS](https://img.shields.io/github/stars/OWASP/owasp-masvs?label=Stars%20MASVS&style=social)
-[![Twitter Follow](https://img.shields.io/twitter/follow/OWASP_MAS.svg?style=social&label=Follow)](https://twitter.com/OWASP_MAS)
+[![Twitter Follow](https://img.shields.io/twitter/follow/OWASP_MAS.svg?style=social&label=Follow)](https://x.com/OWASP_MAS)
 [![MASTG release](https://img.shields.io/github/v/release/OWASP/owasp-mastg?label=MSTG%20release%20version)](https://github.com/OWASP/owasp-mastg/releases)
 [![MASVS release](https://img.shields.io/github/v/release/OWASP/owasp-masvs?label=MASVS%20release%20version)](https://github.com/OWASP/owasp-masvs/releases)
 

--- a/info.md
+++ b/info.md
@@ -23,7 +23,7 @@
 
 - [📢 News](https://mas.owasp.org/news/)
 - [🗣️ Talks](https://mas.owasp.org/talks/)
-- [🙏 Acknowledgements](https://mas.owasp.org/MASTG/Intro/0x02c-Acknowledgements/)
+- [🙏 Acknowledgements](https://mas.owasp.org/MASTG/0x02c-Acknowledgements/)
 - [💬 Questions/Feedback?](https://github.com/OWASP/owasp-mastg/discussions)
 - [Code of Conduct](https://github.com/OWASP/owasp-mastg/blob/master/CODE_OF_CONDUCT.md)
 - [Contributing](https://mas.owasp.org/contributing/1_How_Can_You_Contribute/)

--- a/leaders.md
+++ b/leaders.md
@@ -1,7 +1,7 @@
 ### Leaders
 
-* [Carlos Holguera](mailto://carlos.holguera@owasp.org) (Twitter: [@grepharder](https://twitter.com/grepharder))
-* [Sven Schleier](mailto://sven.schleier@owasp.org) (Twitter: [@bsd_daemon](https://twitter.com/bsd_daemon))
+* [Carlos Holguera](mailto://carlos.holguera@owasp.org) (Twitter: [@grepharder](https://x.com/grepharder))
+* [Sven Schleier](mailto://sven.schleier@owasp.org) (Twitter: [@bsd_daemon](https://x.com/bsd_daemon))
 
 [Contact us](https://mas.owasp.org/#connect-with-us)
 


### PR DESCRIPTION
Update broken links in various markdown files.

* **index.md**
  - Update Twitter link to `https://x.com/OWASP_MAS`
* **leaders.md**
  - Update Twitter link for Carlos Holguera to `https://x.com/grepharder`
  - Update Twitter link for Sven Schleier to `https://x.com/bsd_daemon`
* **info.md**
  - Update Acknowledgements link to `https://mas.owasp.org/MASTG/0x02c-Acknowledgements/`
* **CONTRIBUTING.md**
  - Update Acknowledgements link to `https://mas.owasp.org/MASTG/0x02c-Acknowledgements/`
* **CODE_OF_CONDUCT.md**
  - Update FAQ link to `https://github.com/OWASP/owasp-mastg/blob/master/.github/CODE_OF_CONDUCT.md`

